### PR TITLE
Log each routed request and ship a search UI at /ui/

### DIFF
--- a/docker/compose.ai.yml
+++ b/docker/compose.ai.yml
@@ -72,7 +72,11 @@ services:
       NTFY_TOPIC: llmrouter
       CLASSIFIER_MODE: hybrid
       CLASSIFIER_TIEBREAKER_MODEL: claude-haiku
+      LLMROUTER_DB_PATH: /data/llmrouter.db
+      LOG_REQUESTS: "1"
       LOG_LEVEL: info
+    volumes:
+      - ${DATA}/llmrouter:/data
     depends_on:
       litellm:
         condition: service_healthy

--- a/docker/dockerfiles/llmrouter/Dockerfile
+++ b/docker/dockerfiles/llmrouter/Dockerfile
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
+COPY static ./static
+RUN mkdir -p /data
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/dockerfiles/llmrouter/app.py
+++ b/docker/dockerfiles/llmrouter/app.py
@@ -155,8 +155,8 @@ def heuristic_tier(body: dict[str, Any]) -> tuple[str | None, dict[str, Any]]:
         "tokens": tokens,
         "has_tools": has_tools,
         "has_code": has_code,
-        "has_step_word": hit_step,
-        "has_secret_word": hit_secret,
+        "step_keyword": hit_step,
+        "secret_keyword": hit_secret,
     }
     if hit_secret:
         return "local-thinking", signals
@@ -207,16 +207,6 @@ async def haiku_tiebreaker(body: dict[str, Any]) -> tuple[str, str, dict[str, An
     return mapping.get(digit, "sonnet"), "haiku-tiebreaker", details
 
 
-async def classify(body: dict[str, Any]) -> tuple[str, str, dict[str, Any], dict[str, Any] | None]:
-    tier, signals = heuristic_tier(body)
-    if tier is not None:
-        return tier, "heuristic", signals, None
-    if CLASSIFIER_MODE in ("hybrid", "haiku"):
-        t, reason, details = await haiku_tiebreaker(body)
-        return t, reason, signals, details
-    return "local-thinking", "heuristic-default", signals, None
-
-
 # --- storage ---
 
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_\-]{3,}")
@@ -248,8 +238,8 @@ def _init_db() -> None:
                 approx_tokens INTEGER,
                 has_tools INTEGER DEFAULT 0,
                 has_code INTEGER DEFAULT 0,
-                has_step_word TEXT,
-                has_secret_word TEXT,
+                step_keyword TEXT,
+                secret_keyword TEXT,
                 tiebreaker_prompt TEXT,
                 tiebreaker_response TEXT,
                 tiebreaker_digit TEXT,
@@ -359,7 +349,7 @@ def search_requests(
                        requests.target_model, requests.fallback_applied,
                        requests.is_stream, requests.upstream_status,
                        requests.approx_tokens, requests.has_tools, requests.has_code,
-                       requests.has_step_word, requests.has_secret_word,
+                       requests.step_keyword, requests.secret_keyword,
                        requests.tiebreaker_digit, requests.keywords,
                        substr(coalesce(requests.messages_preview, ''), 1, 240) AS snippet
                 FROM requests {joins}{where_sql}
@@ -461,11 +451,16 @@ async def chat_completions(
     requested = body.get("model", "auto")
     t0 = time.time()
 
-    signals: dict[str, Any] = {}
     tiebreaker: dict[str, Any] | None = None
+    heuristic, signals = heuristic_tier(body)
 
     if requested == "auto":
-        tier, reason, signals, tiebreaker = await classify(body)
+        if heuristic is not None:
+            tier, reason = heuristic, "heuristic"
+        elif CLASSIFIER_MODE in ("hybrid", "haiku"):
+            tier, reason, tiebreaker = await haiku_tiebreaker(body)
+        else:
+            tier, reason = "local-thinking", "heuristic-default"
     elif requested in TIER_TO_MODEL:
         tier, reason = requested, "explicit"
     else:
@@ -494,7 +489,7 @@ async def chat_completions(
         response_headers["x-llmrouter-fallback"] = "ollama-unreachable"
 
     full_text = _messages_text(body.get("messages", []))
-    has_secret = bool(signals.get("has_secret_word"))
+    has_secret = bool(signals.get("secret_keyword"))
     messages_preview = None if has_secret else full_text[:MESSAGES_PREVIEW_CHARS]
     keywords_list = [] if has_secret else extract_keywords(full_text)
 
@@ -523,8 +518,8 @@ async def chat_completions(
         "approx_tokens": signals.get("tokens"),
         "has_tools": 1 if signals.get("has_tools") else 0,
         "has_code": 1 if signals.get("has_code") else 0,
-        "has_step_word": signals.get("has_step_word"),
-        "has_secret_word": signals.get("has_secret_word"),
+        "step_keyword": signals.get("step_keyword"),
+        "secret_keyword": signals.get("secret_keyword"),
         "tiebreaker_prompt": (tiebreaker or {}).get("prompt"),
         "tiebreaker_response": (tiebreaker or {}).get("response"),
         "tiebreaker_digit": (tiebreaker or {}).get("digit"),
@@ -537,7 +532,7 @@ async def chat_completions(
         data = await upstream.aread()
         await client.aclose()
         base_row["duration_ms"] = int((time.time() - t0) * 1000)
-        log_request(base_row)
+        await asyncio.to_thread(log_request, base_row)
         try:
             content = json.loads(data) if data else {}
         except json.JSONDecodeError:
@@ -556,7 +551,7 @@ async def chat_completions(
             await upstream.aclose()
             await client.aclose()
             base_row["duration_ms"] = int((time.time() - t0) * 1000)
-            log_request(base_row)
+            await asyncio.to_thread(log_request, base_row)
 
     return StreamingResponse(
         iter_chunks(),

--- a/docker/dockerfiles/llmrouter/app.py
+++ b/docker/dockerfiles/llmrouter/app.py
@@ -1,21 +1,28 @@
-"""OpenAI-compatible router in front of LiteLLM.
+"""OpenAI-compatible router in front of LiteLLM + request log UI.
 
 Classifies each /v1/chat/completions request (heuristic → Haiku tiebreaker),
 picks a tier (local / local-thinking / haiku / sonnet / opus), and forwards to
 LiteLLM with the model field rewritten. On local-tier selection with an
 unreachable Ollama, transparently promotes to a cloud tier and fires an NTFY
 alert on health transitions.
+
+Every routed request is also logged to a local SQLite DB (with an FTS5 index
+over keywords + a message preview), exposed via a minimal `/ui/` web UI at the
+same port.
 """
 import asyncio
 import json
 import logging
 import os
+import re
+import sqlite3
 import time
+from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, Header, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import FastAPI, Header, HTTPException, Query, Request
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "info").upper(),
@@ -32,6 +39,10 @@ NTFY_TOPIC = os.getenv("NTFY_TOPIC", "llmrouter")
 NTFY_TOKEN = os.getenv("NTFY_TOKEN", "")
 CLASSIFIER_MODE = os.getenv("CLASSIFIER_MODE", "hybrid")
 CLASSIFIER_TIEBREAKER_MODEL = os.getenv("CLASSIFIER_TIEBREAKER_MODEL", "claude-haiku")
+
+DB_PATH = os.getenv("LLMROUTER_DB_PATH", "/data/llmrouter.db")
+LOG_REQUESTS = os.getenv("LOG_REQUESTS", "1") not in ("0", "false", "False", "")
+MESSAGES_PREVIEW_CHARS = 4000
 
 TIER_TO_MODEL: dict[str, str] = {
     "local":          "qwen-local",
@@ -52,10 +63,25 @@ STEP_KEYWORDS = (
     "implement", "analyze", "investigate",
 )
 
+STOPWORDS = frozenset({
+    "about", "above", "after", "again", "against", "also", "another", "been",
+    "before", "being", "below", "between", "both", "could", "does", "doing",
+    "down", "during", "each", "every", "from", "further", "have", "having",
+    "here", "itself", "just", "like", "many", "might", "more", "most", "much",
+    "once", "only", "other", "over", "same", "should", "some", "such", "than",
+    "that", "their", "them", "then", "there", "these", "they", "this", "those",
+    "through", "under", "until", "very", "were", "what", "when", "where",
+    "which", "while", "with", "would", "your", "yours",
+})
+
 HEALTH_TTL = 5.0
 _ollama_state: dict[str, Any] = {"ok": True, "checked_at": 0.0}
 _ollama_lock = asyncio.Lock()
 
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+# --- health + ntfy ---
 
 async def ollama_healthy() -> bool:
     now = time.time()
@@ -96,6 +122,8 @@ async def _notify_ntfy(title: str, message: str, priority: str = "default") -> N
         LOG.warning("ntfy send failed: %s", e)
 
 
+# --- classification ---
+
 def _approx_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
@@ -113,30 +141,37 @@ def _messages_text(messages: list[dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
-def heuristic_tier(body: dict[str, Any]) -> str | None:
-    """First-match-wins rules. Returns None when ambiguous → tiebreaker needed."""
+def heuristic_tier(body: dict[str, Any]) -> tuple[str | None, dict[str, Any]]:
+    """First-match-wins rules. Returns (tier_or_None, signals)."""
     messages = body.get("messages", [])
     text = _messages_text(messages)
     lowered = text.lower()
     tokens = _approx_tokens(text)
     has_tools = bool(body.get("tools") or body.get("functions") or body.get("tool_choice"))
-
-    if any(k in lowered for k in SECRET_KEYWORDS):
-        return "local-thinking"
-    if tokens > 8000:
-        return "sonnet"
-    if has_tools:
-        return "sonnet"
+    hit_secret = next((k for k in SECRET_KEYWORDS if k in lowered), None)
+    hit_step = next((k for k in STEP_KEYWORDS if k in lowered), None)
     has_code = "```" in text
-    has_step = any(k in lowered for k in STEP_KEYWORDS)
-    if tokens < 200 and not has_code and not has_step:
-        return "local"
-    if has_code or has_step:
-        return None
-    return "local-thinking"
+    signals: dict[str, Any] = {
+        "tokens": tokens,
+        "has_tools": has_tools,
+        "has_code": has_code,
+        "has_step_word": hit_step,
+        "has_secret_word": hit_secret,
+    }
+    if hit_secret:
+        return "local-thinking", signals
+    if tokens > 8000:
+        return "sonnet", signals
+    if has_tools:
+        return "sonnet", signals
+    if tokens < 200 and not has_code and not hit_step:
+        return "local", signals
+    if has_code or hit_step:
+        return None, signals
+    return "local-thinking", signals
 
 
-async def haiku_tiebreaker(body: dict[str, Any]) -> tuple[str, str]:
+async def haiku_tiebreaker(body: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
     text = _messages_text(body.get("messages", []))[:4000]
     rate_prompt = (
         "Rate the complexity of this request on a 1-5 scale. "
@@ -144,6 +179,7 @@ async def haiku_tiebreaker(body: dict[str, Any]) -> tuple[str, str]:
         "4=complex multi-step, 5=deep architectural/novel. Output ONLY the digit.\n\n"
         f"---\n{text}\n---"
     )
+    details: dict[str, Any] = {"prompt": rate_prompt, "response": None, "digit": None, "error": None}
     try:
         async with httpx.AsyncClient(timeout=10.0) as c:
             r = await c.post(
@@ -157,27 +193,235 @@ async def haiku_tiebreaker(body: dict[str, Any]) -> tuple[str, str]:
                 },
             )
         content = r.json()["choices"][0]["message"]["content"]
+        details["response"] = content
         digit = next((ch for ch in content if ch.isdigit()), None)
+        details["digit"] = digit
         if digit is None:
             raise ValueError(f"no digit in Haiku response: {content!r}")
     except Exception as e:
         LOG.warning("tiebreaker failed, defaulting to sonnet: %s", e)
-        return "sonnet", "tiebreaker-failed-default"
+        details["error"] = str(e)
+        return "sonnet", "tiebreaker-failed-default", details
     mapping = {"1": "local-thinking", "2": "local-thinking",
                "3": "sonnet", "4": "opus", "5": "opus"}
-    return mapping.get(digit, "sonnet"), "haiku-tiebreaker"
+    return mapping.get(digit, "sonnet"), "haiku-tiebreaker", details
 
 
-async def classify(body: dict[str, Any]) -> tuple[str, str]:
-    tier = heuristic_tier(body)
+async def classify(body: dict[str, Any]) -> tuple[str, str, dict[str, Any], dict[str, Any] | None]:
+    tier, signals = heuristic_tier(body)
     if tier is not None:
-        return tier, "heuristic"
+        return tier, "heuristic", signals, None
     if CLASSIFIER_MODE in ("hybrid", "haiku"):
-        return await haiku_tiebreaker(body)
-    return "local-thinking", "heuristic-default"
+        t, reason, details = await haiku_tiebreaker(body)
+        return t, reason, signals, details
+    return "local-thinking", "heuristic-default", signals, None
 
+
+# --- storage ---
+
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_\-]{3,}")
+_db_ready = False
+
+
+def _init_db() -> None:
+    global _db_ready
+    if _db_ready:
+        return
+    Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    try:
+        conn.executescript("""
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+
+            CREATE TABLE IF NOT EXISTS requests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts REAL NOT NULL,
+                duration_ms INTEGER,
+                requested_model TEXT,
+                tier TEXT,
+                reason TEXT,
+                target_model TEXT,
+                fallback_applied INTEGER DEFAULT 0,
+                is_stream INTEGER DEFAULT 0,
+                upstream_status INTEGER,
+                approx_tokens INTEGER,
+                has_tools INTEGER DEFAULT 0,
+                has_code INTEGER DEFAULT 0,
+                has_step_word TEXT,
+                has_secret_word TEXT,
+                tiebreaker_prompt TEXT,
+                tiebreaker_response TEXT,
+                tiebreaker_digit TEXT,
+                tiebreaker_error TEXT,
+                keywords TEXT,
+                messages_preview TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_requests_ts   ON requests(ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_requests_tier ON requests(tier);
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS requests_fts USING fts5(
+                keywords, messages_preview,
+                content='requests', content_rowid='id',
+                tokenize='porter unicode61'
+            );
+
+            CREATE TRIGGER IF NOT EXISTS requests_ai AFTER INSERT ON requests BEGIN
+                INSERT INTO requests_fts(rowid, keywords, messages_preview)
+                VALUES (new.id, coalesce(new.keywords, ''), coalesce(new.messages_preview, ''));
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS requests_ad AFTER DELETE ON requests BEGIN
+                INSERT INTO requests_fts(requests_fts, rowid, keywords, messages_preview)
+                VALUES ('delete', old.id, coalesce(old.keywords, ''), coalesce(old.messages_preview, ''));
+            END;
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+    _db_ready = True
+
+
+def extract_keywords(text: str, max_n: int = 30) -> list[str]:
+    freq: dict[str, int] = {}
+    for w in _WORD_RE.findall(text.lower()):
+        if w in STOPWORDS:
+            continue
+        freq[w] = freq.get(w, 0) + 1
+    ranked = sorted(freq.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [w for w, _ in ranked[:max_n]]
+
+
+def log_request(row: dict[str, Any]) -> None:
+    if not LOG_REQUESTS:
+        return
+    try:
+        _init_db()
+        conn = sqlite3.connect(DB_PATH, check_same_thread=False, timeout=5.0)
+        try:
+            keys = list(row.keys())
+            conn.execute(
+                f"INSERT INTO requests ({','.join(keys)}) VALUES ({','.join('?' * len(keys))})",
+                [row[k] for k in keys],
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as e:
+        LOG.warning("failed to log request: %s", e)
+
+
+_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9_\-]+")
+
+
+def _fts_match(q: str) -> str:
+    """Turn a freeform search query into an FTS5 MATCH expression."""
+    tokens = _FTS_TOKEN_RE.findall(q)
+    return " ".join(f'"{t}"*' for t in tokens)
+
+
+def search_requests(
+    q: str = "",
+    tier: str | None = None,
+    since: float | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    _init_db()
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        where: list[str] = []
+        params: list[Any] = []
+        joins = ""
+
+        match = _fts_match(q) if q else ""
+        if match:
+            joins = " JOIN requests_fts ON requests_fts.rowid = requests.id "
+            where.append("requests_fts MATCH ?")
+            params.append(match)
+        if tier:
+            where.append("requests.tier = ?")
+            params.append(tier)
+        if since is not None:
+            where.append("requests.ts >= ?")
+            params.append(since)
+        where_sql = f" WHERE {' AND '.join(where)}" if where else ""
+
+        total = int(conn.execute(
+            f"SELECT COUNT(*) AS n FROM requests {joins}{where_sql}", params,
+        ).fetchone()["n"])
+
+        rows = conn.execute(
+            f"""SELECT requests.id, requests.ts, requests.duration_ms,
+                       requests.requested_model, requests.tier, requests.reason,
+                       requests.target_model, requests.fallback_applied,
+                       requests.is_stream, requests.upstream_status,
+                       requests.approx_tokens, requests.has_tools, requests.has_code,
+                       requests.has_step_word, requests.has_secret_word,
+                       requests.tiebreaker_digit, requests.keywords,
+                       substr(coalesce(requests.messages_preview, ''), 1, 240) AS snippet
+                FROM requests {joins}{where_sql}
+                ORDER BY requests.ts DESC
+                LIMIT ? OFFSET ?""",
+            [*params, limit, offset],
+        ).fetchall()
+        return {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "items": [dict(r) for r in rows],
+        }
+    finally:
+        conn.close()
+
+
+def get_request(req_id: int) -> dict[str, Any] | None:
+    _init_db()
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute("SELECT * FROM requests WHERE id = ?", (req_id,)).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def stats() -> dict[str, Any]:
+    _init_db()
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        total = int(conn.execute("SELECT COUNT(*) AS n FROM requests").fetchone()["n"])
+        by_tier = [
+            {"tier": r["tier"], "count": r["n"]}
+            for r in conn.execute(
+                "SELECT tier, COUNT(*) AS n FROM requests GROUP BY tier ORDER BY n DESC"
+            ).fetchall()
+        ]
+        by_reason = [
+            {"reason": r["reason"], "count": r["n"]}
+            for r in conn.execute(
+                "SELECT reason, COUNT(*) AS n FROM requests GROUP BY reason ORDER BY n DESC"
+            ).fetchall()
+        ]
+        return {"total": total, "by_tier": by_tier, "by_reason": by_reason}
+    finally:
+        conn.close()
+
+
+# --- app ---
 
 app = FastAPI(title="llmrouter")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    try:
+        _init_db()
+    except Exception as e:
+        LOG.warning("db init failed at startup: %s", e)
 
 
 def _check_auth(authorization: str | None) -> None:
@@ -215,9 +459,13 @@ async def chat_completions(
     _check_auth(authorization)
     body = await request.json()
     requested = body.get("model", "auto")
+    t0 = time.time()
+
+    signals: dict[str, Any] = {}
+    tiebreaker: dict[str, Any] | None = None
 
     if requested == "auto":
-        tier, reason = await classify(body)
+        tier, reason, signals, tiebreaker = await classify(body)
     elif requested in TIER_TO_MODEL:
         tier, reason = requested, "explicit"
     else:
@@ -245,6 +493,11 @@ async def chat_completions(
     if fallback_applied:
         response_headers["x-llmrouter-fallback"] = "ollama-unreachable"
 
+    full_text = _messages_text(body.get("messages", []))
+    has_secret = bool(signals.get("has_secret_word"))
+    messages_preview = None if has_secret else full_text[:MESSAGES_PREVIEW_CHARS]
+    keywords_list = [] if has_secret else extract_keywords(full_text)
+
     client = httpx.AsyncClient(timeout=None)
     upstream_req = client.build_request(
         "POST",
@@ -257,9 +510,34 @@ async def chat_completions(
     )
     upstream = await client.send(upstream_req, stream=is_stream)
 
+    base_row: dict[str, Any] = {
+        "ts": t0,
+        "duration_ms": None,
+        "requested_model": requested,
+        "tier": tier,
+        "reason": reason,
+        "target_model": target_model,
+        "fallback_applied": 1 if fallback_applied else 0,
+        "is_stream": 1 if is_stream else 0,
+        "upstream_status": upstream.status_code,
+        "approx_tokens": signals.get("tokens"),
+        "has_tools": 1 if signals.get("has_tools") else 0,
+        "has_code": 1 if signals.get("has_code") else 0,
+        "has_step_word": signals.get("has_step_word"),
+        "has_secret_word": signals.get("has_secret_word"),
+        "tiebreaker_prompt": (tiebreaker or {}).get("prompt"),
+        "tiebreaker_response": (tiebreaker or {}).get("response"),
+        "tiebreaker_digit": (tiebreaker or {}).get("digit"),
+        "tiebreaker_error": (tiebreaker or {}).get("error"),
+        "keywords": " ".join(keywords_list) if keywords_list else None,
+        "messages_preview": messages_preview,
+    }
+
     if not is_stream:
         data = await upstream.aread()
         await client.aclose()
+        base_row["duration_ms"] = int((time.time() - t0) * 1000)
+        log_request(base_row)
         try:
             content = json.loads(data) if data else {}
         except json.JSONDecodeError:
@@ -277,6 +555,8 @@ async def chat_completions(
         finally:
             await upstream.aclose()
             await client.aclose()
+            base_row["duration_ms"] = int((time.time() - t0) * 1000)
+            log_request(base_row)
 
     return StreamingResponse(
         iter_chunks(),
@@ -284,3 +564,48 @@ async def chat_completions(
         media_type=upstream.headers.get("content-type", "text/event-stream"),
         headers=response_headers,
     )
+
+
+# --- UI ---
+
+@app.get("/", include_in_schema=False)
+@app.get("/ui", include_in_schema=False)
+@app.get("/ui/", include_in_schema=False)
+async def ui_index():
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon():
+    return Response(status_code=204)
+
+
+@app.get("/ui/api/stats")
+async def ui_stats(authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    _check_auth(authorization)
+    return stats()
+
+
+@app.get("/ui/api/requests")
+async def ui_list_requests(
+    q: str = Query(default=""),
+    tier: str | None = Query(default=None),
+    since: float | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    return search_requests(q=q, tier=tier, since=since, limit=limit, offset=offset)
+
+
+@app.get("/ui/api/requests/{req_id}")
+async def ui_get_request(
+    req_id: int,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _check_auth(authorization)
+    row = get_request(req_id)
+    if not row:
+        raise HTTPException(404, "not found")
+    return row

--- a/docker/dockerfiles/llmrouter/static/index.html
+++ b/docker/dockerfiles/llmrouter/static/index.html
@@ -200,8 +200,8 @@
       <option value="604800">7d</option>
       <option value="2592000">30d</option>
     </select>
-    <button id="refresh" title="refresh">↻</button>
-    <button id="logout" title="clear stored API key">⎋</button>
+    <button id="refresh" title="refresh" aria-label="refresh">↻</button>
+    <button id="logout" title="clear stored API key" aria-label="clear stored API key">⎋</button>
   </div>
 </header>
 
@@ -334,8 +334,8 @@ function renderList(res) {
     return;
   }
   rows.innerHTML = res.items.map(r => {
-    const secret = r.has_secret_word ? "secret" : "";
-    const snippet = r.has_secret_word
+    const secret = r.secret_keyword ? "secret" : "";
+    const snippet = r.secret_keyword
       ? "[message preview withheld — secret keyword matched]"
       : (r.snippet || "(empty prompt)");
     const meta = [
@@ -382,7 +382,7 @@ function flag(label, value, hintWhenTrue) {
 
 function renderDetail(r) {
   const kv = (k, v) => `<div class="k">${k}</div><div class="v">${v}</div>`;
-  const preview = r.has_secret_word
+  const preview = r.secret_keyword
     ? "<em>withheld (secret keyword matched in the prompt)</em>"
     : escapeHtml(r.messages_preview || "(empty prompt)");
 
@@ -424,8 +424,8 @@ function renderDetail(r) {
         <span class="chip muted">tokens: ${r.approx_tokens ?? "?"}</span>
         ${flag("tools", r.has_tools)}
         ${flag("code fence", r.has_code)}
-        <span class="chip ${r.has_step_word ? "tier-local-thinking" : "muted"}" title="step-planning keyword matched">step: ${escapeHtml(r.has_step_word || "no")}</span>
-        <span class="chip ${r.has_secret_word ? "tier-opus" : "muted"}" title="secret-like keyword matched">secret: ${escapeHtml(r.has_secret_word || "no")}</span>
+        <span class="chip ${r.step_keyword ? "tier-local-thinking" : "muted"}" title="step-planning keyword matched">step: ${escapeHtml(r.step_keyword || "no")}</span>
+        <span class="chip ${r.secret_keyword ? "tier-opus" : "muted"}" title="secret-like keyword matched">secret: ${escapeHtml(r.secret_keyword || "no")}</span>
       </div>
     </div>
 

--- a/docker/dockerfiles/llmrouter/static/index.html
+++ b/docker/dockerfiles/llmrouter/static/index.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>llmrouter — request log</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --panel-2: #1f2630;
+    --border: #2a313c;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --ok: #3fb950;
+    --warn: #d29922;
+    --err: #f85149;
+    --local: #8b949e;
+    --local-thinking: #58a6ff;
+    --haiku: #3fb950;
+    --sonnet: #a371f7;
+    --opus: #f0883e;
+    --none: #6e7681;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    font-size: 14px;
+  }
+  header {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; letter-spacing: 0.2px; }
+  header h1 .muted { color: var(--muted); font-weight: 400; }
+  .search {
+    flex: 1 1 320px;
+    min-width: 260px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  input, select, button {
+    background: var(--panel-2);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    font-family: inherit;
+  }
+  input[type=search] { flex: 1; }
+  input:focus, select:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
+  button { cursor: pointer; }
+  button:hover { background: #263040; }
+  .chips { display: flex; gap: 6px; flex-wrap: wrap; }
+  .chip {
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    color: #0d1117;
+    white-space: nowrap;
+  }
+  .chip.tier-local          { background: var(--local); }
+  .chip.tier-local-thinking { background: var(--local-thinking); }
+  .chip.tier-haiku          { background: var(--haiku); }
+  .chip.tier-sonnet         { background: var(--sonnet); color: #fff; }
+  .chip.tier-opus           { background: var(--opus); }
+  .chip.tier-none           { background: var(--none); color: #fff; }
+  .chip.muted {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  main { display: grid; grid-template-columns: minmax(0, 1fr) 420px; gap: 0; }
+  @media (max-width: 900px) { main { grid-template-columns: 1fr; } }
+  .list { border-right: 1px solid var(--border); min-height: calc(100vh - 54px); }
+  .summary {
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--border);
+    color: var(--muted);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .summary .tier-stats { display: flex; gap: 6px; flex-wrap: wrap; }
+  .row {
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 64px 100px 1fr auto;
+    gap: 12px;
+    align-items: start;
+  }
+  .row:hover { background: var(--panel); }
+  .row.selected { background: var(--panel-2); }
+  .row .time { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 12px; }
+  .row .snippet { color: var(--fg); overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+  .row .meta { color: var(--muted); font-size: 12px; white-space: nowrap; }
+  .row.secret .snippet { color: var(--muted); font-style: italic; }
+  aside {
+    padding: 16px 20px;
+    overflow-y: auto;
+    min-height: calc(100vh - 54px);
+    position: sticky;
+    top: 54px;
+    max-height: calc(100vh - 54px);
+  }
+  aside h2 { font-size: 14px; margin: 0 0 10px 0; }
+  .kv { display: grid; grid-template-columns: 130px 1fr; gap: 4px 10px; margin: 8px 0; }
+  .kv .k { color: var(--muted); font-size: 12px; }
+  .kv .v { font-size: 13px; word-break: break-word; }
+  .section {
+    margin: 14px 0;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--panel);
+  }
+  .section h3 {
+    margin: 0 0 8px 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  pre {
+    margin: 0;
+    padding: 10px;
+    background: #0a0d12;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    max-height: 320px;
+    overflow: auto;
+  }
+  .empty { padding: 60px 20px; color: var(--muted); text-align: center; }
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .overlay .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 24px;
+    width: 360px;
+    max-width: 90vw;
+  }
+  .overlay h2 { margin: 0 0 10px 0; font-size: 16px; }
+  .overlay p  { margin: 0 0 14px 0; color: var(--muted); font-size: 13px; }
+  .row-flex { display: flex; gap: 8px; }
+  .hide { display: none !important; }
+  .err { color: var(--err); }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>llmrouter <span class="muted">— request log</span></h1>
+  <div class="search">
+    <input id="q" type="search" placeholder="search keywords / messages (e.g. python sonnet refactor)" autocomplete="off" />
+    <select id="tier">
+      <option value="">all tiers</option>
+      <option>local</option>
+      <option>local-thinking</option>
+      <option>haiku</option>
+      <option>sonnet</option>
+      <option>opus</option>
+    </select>
+    <select id="since">
+      <option value="">all time</option>
+      <option value="3600">1h</option>
+      <option value="86400">24h</option>
+      <option value="604800">7d</option>
+      <option value="2592000">30d</option>
+    </select>
+    <button id="refresh" title="refresh">↻</button>
+    <button id="logout" title="clear stored API key">⎋</button>
+  </div>
+</header>
+
+<main>
+  <section class="list">
+    <div class="summary">
+      <div id="result-summary">—</div>
+      <div id="tier-stats" class="tier-stats"></div>
+    </div>
+    <div id="rows"></div>
+  </section>
+  <aside id="detail">
+    <div class="empty">Select a request to see classification details.</div>
+  </aside>
+</main>
+
+<div id="login" class="overlay hide">
+  <div class="card">
+    <h2>Unlock</h2>
+    <p>Enter your router API key to view the request log. It is stored in your browser only.</p>
+    <div class="row-flex">
+      <input id="login-key" type="password" placeholder="ROUTER_API_KEY" style="flex:1;" />
+      <button id="login-go">Unlock</button>
+    </div>
+    <p id="login-err" class="err hide" style="margin-top:10px;">Invalid key.</p>
+  </div>
+</div>
+
+<script>
+const KEY_STORAGE = "llmrouter.apikey";
+let apiKey = localStorage.getItem(KEY_STORAGE) || "";
+let selectedId = null;
+let debounceTimer = null;
+
+function fmtTime(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleString();
+}
+function relTime(ts) {
+  const secs = Math.max(0, Date.now() / 1000 - ts);
+  if (secs < 60)     return Math.floor(secs) + "s";
+  if (secs < 3600)   return Math.floor(secs / 60) + "m";
+  if (secs < 86400)  return Math.floor(secs / 3600) + "h";
+  return Math.floor(secs / 86400) + "d";
+}
+function tierChip(t) {
+  const cls = "tier-" + (t || "none");
+  return `<span class="chip ${cls}">${t || "—"}</span>`;
+}
+function escapeHtml(s) {
+  if (s == null) return "";
+  return String(s)
+    .replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;")
+    .replaceAll('"',"&quot;").replaceAll("'","&#39;");
+}
+
+async function api(path) {
+  const r = await fetch(path, { headers: { Authorization: "Bearer " + apiKey } });
+  if (r.status === 401) {
+    showLogin(true);
+    throw new Error("unauthorized");
+  }
+  if (!r.ok) throw new Error("HTTP " + r.status);
+  return r.json();
+}
+
+function showLogin(isError) {
+  document.getElementById("login").classList.remove("hide");
+  document.getElementById("login-err").classList.toggle("hide", !isError);
+  document.getElementById("login-key").focus();
+}
+function hideLogin() {
+  document.getElementById("login").classList.add("hide");
+}
+
+async function tryUnlock() {
+  const v = document.getElementById("login-key").value.trim();
+  if (!v) return;
+  apiKey = v;
+  try {
+    await api("/ui/api/stats");
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    hideLogin();
+    refresh();
+  } catch (_) {
+    document.getElementById("login-err").classList.remove("hide");
+  }
+}
+
+function logout() {
+  localStorage.removeItem(KEY_STORAGE);
+  apiKey = "";
+  showLogin(false);
+}
+
+async function loadStats() {
+  try {
+    const s = await api("/ui/api/stats");
+    const el = document.getElementById("tier-stats");
+    el.innerHTML = s.by_tier.map(
+      t => `<span class="chip ${"tier-" + (t.tier || "none")}">${t.tier || "—"}: ${t.count}</span>`
+    ).join("");
+  } catch (_) { /* ignored */ }
+}
+
+async function loadList() {
+  const q     = document.getElementById("q").value.trim();
+  const tier  = document.getElementById("tier").value;
+  const since = document.getElementById("since").value;
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  if (tier) params.set("tier", tier);
+  if (since) params.set("since", (Date.now() / 1000 - parseInt(since)).toFixed(0));
+  try {
+    const res = await api("/ui/api/requests?" + params.toString());
+    renderList(res);
+  } catch (e) {
+    document.getElementById("rows").innerHTML = `<div class="empty err">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function renderList(res) {
+  const s = document.getElementById("result-summary");
+  s.textContent = res.total === 0
+    ? "no requests"
+    : `${res.total} request${res.total === 1 ? "" : "s"}` + (res.items.length < res.total ? ` (showing ${res.items.length})` : "");
+  const rows = document.getElementById("rows");
+  if (!res.items.length) {
+    rows.innerHTML = `<div class="empty">Nothing matched.</div>`;
+    return;
+  }
+  rows.innerHTML = res.items.map(r => {
+    const secret = r.has_secret_word ? "secret" : "";
+    const snippet = r.has_secret_word
+      ? "[message preview withheld — secret keyword matched]"
+      : (r.snippet || "(empty prompt)");
+    const meta = [
+      r.approx_tokens != null ? r.approx_tokens + " tok" : null,
+      r.duration_ms   != null ? r.duration_ms + " ms" : null,
+      r.is_stream     ? "stream" : null,
+      r.fallback_applied ? "fallback" : null,
+      r.tiebreaker_digit ? "haiku=" + r.tiebreaker_digit : null,
+    ].filter(Boolean).join(" · ");
+    return `
+      <div class="row ${secret} ${r.id === selectedId ? "selected" : ""}" data-id="${r.id}">
+        <div class="time" title="${escapeHtml(fmtTime(r.ts))}">${relTime(r.ts)} ago</div>
+        <div>${tierChip(r.tier)}<div class="meta">${escapeHtml(r.reason || "")}</div></div>
+        <div>
+          <div class="snippet">${escapeHtml(snippet)}</div>
+          <div class="meta">${escapeHtml(meta)}</div>
+        </div>
+        <div class="meta">#${r.id}</div>
+      </div>`;
+  }).join("");
+  rows.querySelectorAll(".row").forEach(el => {
+    el.onclick = () => selectRow(parseInt(el.dataset.id));
+  });
+}
+
+async function selectRow(id) {
+  selectedId = id;
+  document.querySelectorAll(".row").forEach(el => {
+    el.classList.toggle("selected", parseInt(el.dataset.id) === id);
+  });
+  try {
+    const r = await api("/ui/api/requests/" + id);
+    renderDetail(r);
+  } catch (e) {
+    document.getElementById("detail").innerHTML =
+      `<div class="empty err">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function flag(label, value, hintWhenTrue) {
+  const on = !!value;
+  return `<span class="chip ${on ? "tier-haiku" : "muted"}" title="${escapeHtml(hintWhenTrue || "")}">${label}: ${on ? (value === true || value === 1 ? "yes" : value) : "no"}</span>`;
+}
+
+function renderDetail(r) {
+  const kv = (k, v) => `<div class="k">${k}</div><div class="v">${v}</div>`;
+  const preview = r.has_secret_word
+    ? "<em>withheld (secret keyword matched in the prompt)</em>"
+    : escapeHtml(r.messages_preview || "(empty prompt)");
+
+  const tiebreakerSection = r.tiebreaker_prompt ? `
+    <div class="section">
+      <h3>Haiku tiebreaker</h3>
+      <div class="kv">
+        ${kv("digit", `<b>${escapeHtml(r.tiebreaker_digit || "—")}</b>`)}
+        ${kv("raw response", `<code>${escapeHtml(r.tiebreaker_response || "—")}</code>`)}
+        ${r.tiebreaker_error ? kv("error", `<span class="err">${escapeHtml(r.tiebreaker_error)}</span>`) : ""}
+      </div>
+      <details><summary style="cursor:pointer;color:var(--muted);font-size:12px;">show prompt sent to Haiku</summary>
+        <pre>${escapeHtml(r.tiebreaker_prompt)}</pre>
+      </details>
+    </div>
+  ` : "";
+
+  const kwList = (r.keywords || "").split(/\s+/).filter(Boolean);
+  const kwChips = kwList.length
+    ? kwList.map(k => `<span class="chip muted" style="cursor:pointer" data-kw="${escapeHtml(k)}">${escapeHtml(k)}</span>`).join(" ")
+    : `<span class="muted">none</span>`;
+
+  document.getElementById("detail").innerHTML = `
+    <h2>Request #${r.id} ${tierChip(r.tier)}</h2>
+    <div class="kv">
+      ${kv("timestamp", escapeHtml(fmtTime(r.ts)))}
+      ${kv("requested", `<code>${escapeHtml(r.requested_model || "—")}</code>`)}
+      ${kv("target", `<code>${escapeHtml(r.target_model || "—")}</code>`)}
+      ${kv("reason", `<code>${escapeHtml(r.reason || "—")}</code>`)}
+      ${kv("duration", (r.duration_ms == null ? "—" : r.duration_ms + " ms"))}
+      ${kv("upstream", r.upstream_status || "—")}
+      ${kv("stream", r.is_stream ? "yes" : "no")}
+      ${kv("fallback", r.fallback_applied ? '<span class="err">yes (ollama unreachable)</span>' : "no")}
+    </div>
+
+    <div class="section">
+      <h3>Classification signals</h3>
+      <div class="chips">
+        <span class="chip muted">tokens: ${r.approx_tokens ?? "?"}</span>
+        ${flag("tools", r.has_tools)}
+        ${flag("code fence", r.has_code)}
+        <span class="chip ${r.has_step_word ? "tier-local-thinking" : "muted"}" title="step-planning keyword matched">step: ${escapeHtml(r.has_step_word || "no")}</span>
+        <span class="chip ${r.has_secret_word ? "tier-opus" : "muted"}" title="secret-like keyword matched">secret: ${escapeHtml(r.has_secret_word || "no")}</span>
+      </div>
+    </div>
+
+    ${tiebreakerSection}
+
+    <div class="section">
+      <h3>Keywords</h3>
+      <div class="chips">${kwChips}</div>
+    </div>
+
+    <div class="section">
+      <h3>Messages preview</h3>
+      <pre>${preview}</pre>
+    </div>
+  `;
+
+  document.querySelectorAll("#detail .chip[data-kw]").forEach(el => {
+    el.onclick = () => {
+      const input = document.getElementById("q");
+      input.value = el.dataset.kw;
+      refresh();
+    };
+  });
+}
+
+function refresh() {
+  loadStats();
+  loadList();
+}
+
+function debounced() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(refresh, 250);
+}
+
+document.getElementById("q").addEventListener("input", debounced);
+document.getElementById("tier").addEventListener("change", refresh);
+document.getElementById("since").addEventListener("change", refresh);
+document.getElementById("refresh").addEventListener("click", refresh);
+document.getElementById("logout").addEventListener("click", logout);
+document.getElementById("login-go").addEventListener("click", tryUnlock);
+document.getElementById("login-key").addEventListener("keydown", e => { if (e.key === "Enter") tryUnlock(); });
+
+if (!apiKey) showLogin(false);
+else refresh();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Resolves #1.

## Summary
- Persist every `/v1/chat/completions` routing decision to a SQLite DB under `${DATA}/llmrouter` — tier, reason, heuristic signals, the Haiku tiebreaker prompt + raw response + extracted digit, fallback flag, duration, and upstream status.
- Add a single-page search UI at `/ui/` (also `/`, `/ui`) with FTS5 keyword search, tier + time-range filters, and a detail pane that surfaces the exact classification trail. Unlocks via the existing `ROUTER_API_KEY`, cached in `localStorage`.
- Secret-guard: when the heuristic hits a secret keyword, the message preview and extracted keywords are withheld from the DB — only the flag is stored.

## Test plan
- [x] `python -c "ast.parse(...)"` on `app.py`
- [x] `docker compose -f compose.ai.yml config` validates
- [x] In-process smoke test: DB init, insert, FTS5 prefix search, tier filter, detail fetch, stats aggregation
- [x] On server: `docker compose up -d --build llmrouter`, hit `/ui/`, confirm routing decisions from live Open WebUI traffic show up with Haiku tiebreaker details
- [ ] Verify secret-keyword requests land without `messages_preview` or `keywords`
- [ ] Confirm `${DATA}/llmrouter/llmrouter.db` persists across container recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)