### PR TITLE
Close all 15 Dependabot alerts + enable auto-PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # Python requirements in the custom MCP server images
+  # (docker/dockerfiles/mcp-*/requirements.txt)
+  - package-ecosystem: "pip"
+    directories:
+      - "/docker/dockerfiles/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      mcp-python:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Base images in our custom Dockerfiles
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/dockerfiles"
+      - "/docker/dockerfiles/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dockerfile-bases:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Image tags in the compose files
+  - package-ecosystem: "docker-compose"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      compose-images:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions workflow pins
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/docker/dockerfiles/mcp-elev/requirements.txt
+++ b/docker/dockerfiles/mcp-elev/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp==2.14.7
+fastmcp==3.2.4
 httpx==0.28.1

--- a/docker/dockerfiles/mcp-nominatim/requirements.txt
+++ b/docker/dockerfiles/mcp-nominatim/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp==2.14.7
+fastmcp==3.2.4
 httpx==0.28.1

--- a/docker/dockerfiles/mcp-photon/requirements.txt
+++ b/docker/dockerfiles/mcp-photon/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp==2.14.7
+fastmcp==3.2.4
 httpx==0.28.1

--- a/docker/dockerfiles/mcp-searxng/requirements.txt
+++ b/docker/dockerfiles/mcp-searxng/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp==2.14.7
+fastmcp==3.2.4
 httpx==0.28.1

--- a/docker/dockerfiles/mcp-valhalla/requirements.txt
+++ b/docker/dockerfiles/mcp-valhalla/requirements.txt
@@ -1,2 +1,2 @@
-fastmcp==2.14.7
+fastmcp==3.2.4
 httpx==0.28.1


### PR DESCRIPTION
## Summary

- Bumps `fastmcp==2.14.7` → `fastmcp==3.2.4` in all five custom MCP server requirements files, closing the 15 open Dependabot alerts (3 CVEs × 5 services — critical SSRF, high OAuth-proxy confused-deputy, medium Gemini-CLI command injection).
- Adds `.github/dependabot.yml` so future bumps arrive as weekly auto-PRs (grouped minor/patch, individual major) across `pip`, `docker`, `docker-compose`, and `github-actions` ecosystems.

## Why the fastmcp bump is safe without code changes

None of our MCP apps use the actually-vulnerable code paths (`OpenAPIProvider`, OAuth proxy, Gemini CLI) — all five use custom Starlette Bearer-token middleware. The 2.x→3.x API surface we rely on is unchanged:

- `FastMCP("name")` single-positional constructor: still works
- `@mcp.tool` bare decorator: still works
- `mcp.http_app(transport="streamable-http")`: same signature, same return type

Verified against `jlowin/fastmcp@main` source (`src/fastmcp/server/server.py`, `src/fastmcp/server/mixins/transport.py`) and `pyproject.toml` (confirms `httpx>=0.28.1,<1.0`, so our `httpx==0.28.1` pin stays compatible).

## Test plan

- [x] `docker build` of `mcp-elev` succeeds — `fastmcp-3.2.4` + `httpx-0.28.1` resolve cleanly via pip
- [x] `python -c "import app"` against the rebuilt image returns `OK StarletteWithLifespan 2` (health route + MCP mount instantiate identically under 3.2.4)
- [ ] Server-side rebuild & redeploy of all five MCP services: `docker compose build mcp-elev mcp-nominatim mcp-photon mcp-searxng mcp-valhalla && docker compose up -d ...`
- [ ] Hit `/health` on each container
- [ ] End-to-end: invoke one tool through the existing LiteLLM / Open WebUI → MCP route to confirm Bearer auth + streamable-http transport still work
- [ ] Re-run `gh api repos/:owner/:repo/dependabot/alerts --jq '[.[] | select(.state=="open")] | length'` → expect `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)