### PR TITLE
Add RomM library service

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This is a monorepo for a NixOS-based homeserver running 50+ Docker containers. D
 
 ### Repository Layout
 
-- `docker/` — Docker Compose orchestration (17 category files, 50+ services)
+- `docker/` — Docker Compose orchestration (18 category files, 50+ services)
 - `nixos/` — NixOS system configuration (`configuration.nix`)
 - `homepage/` — Homepage dashboard YAML config
 - `mail-config/` — Portable email/contacts setup (aerc, khard, vdirsyncer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ A monorepo for homeserver infrastructure (domain: `danteb.com`). The server runs
 
 | Directory | Purpose |
 |-----------|---------|
-| `docker/` | Docker Compose orchestration — 17 category files, 50+ services |
+| `docker/` | Docker Compose orchestration — 18 category files, 50+ services |
 | `nixos/` | NixOS system configuration — single `configuration.nix` |
 | `homepage/` | Homepage dashboard YAML config |
 | `mail-config/` | Portable email/contacts setup (aerc, khard, vdirsyncer) — also used on macOS |
@@ -72,6 +72,7 @@ Some Docker Compose services build from repos outside this monorepo. Their paths
 | `compose.matrix.yml` | synapse, element, coturn, livekit, lk-jwt-service, postgres |
 | `compose.media.yml` | plex, jellyfin, anime-relations, komga, komf, suwayomi, calibre-web, postgres |
 | `compose.nextcloud.yml` | nextcloud, nextcloud_cron, postgres, redis |
+| `compose.romm.yml` | romm, mariadb |
 | `compose.searxng.yml` | searxng, redis (valkey) |
 | `compose.starr.yml` | radarr, sonarr, bazarr, prowlarr, seerr, tdarr, recyclarr |
 | `compose.utilities.yml` | vaultwarden, syncthing, ntfy, adguardhome, wg-easy, it-tools, code-server, convertx, snapotter, stirling-pdf, changedetection-io, sockpuppetbrowser |

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Monorepo for my NixOS-based home server infrastructure. 50+ Docker containers, N
 | **Auth** | Authelia + LDAP |
 | **Utilities** | Vaultwarden, Syncthing, ntfy, SearXNG |
 | **Networking** | Nginx Proxy Manager, ddclient, Endlessh |
-| **Gaming** | Minecraft, Satisfactory |
+| **Gaming** | RomM, Minecraft, Satisfactory |
 | **Dashboards** | Homepage, DashDot |
 
 ## Repository Layout
 
 ```
-docker/              Docker Compose orchestration (17 category files)
+docker/              Docker Compose orchestration (18 category files)
 nixos/               NixOS system configuration (configuration.nix)
 homepage/            Homepage dashboard YAML config
 mail-config/         Portable email/contacts (aerc, khard, vdirsyncer)

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,7 @@ Docker Compose configuration for my home server, organized into logical service 
 ├── compose.matrix.yml      # Matrix communication stack (Synapse, Element, Coturn, LiveKit)
 ├── compose.media.yml       # Media consumption (Plex, Jellyfin, ARM, Komga, Suwayomi)
 ├── compose.nextcloud.yml   # Nextcloud cloud storage stack
+├── compose.romm.yml        # RomM library and MariaDB
 ├── compose.searxng.yml     # SearXNG search engine stack
 ├── compose.starr.yml       # *arr apps + Seerr + Whisper ASR + Tdarr
 ├── compose.utilities.yml   # Utilities (Vaultwarden, Syncthing, ntfy)
@@ -57,6 +58,7 @@ docker compose -f compose.gaming.yml up -d
 | **Matrix** | synapse, synapse_postgres, element, coturn, livekit, lk-jwt-service |
 | **Media** | plex, jellyfin, anime-relations, komga, komf, suwayomi, suwayomi_postgres |
 | **Nextcloud** | nextcloud, nextcloud_cron, nextcloud_postgres, nextcloud_redis |
+| **RomM** | romm, romm-db |
 | **SearXNG** | searxng, searxng_redis |
 | **Starr** | radarr, sonarr, bazarr, prowlarr, recyclarr, seerr, whisperasr, tdarr |
 | **Utilities** | vaultwarden, syncthing, ntfy |
@@ -94,6 +96,10 @@ See [NEXTCLOUD.md](docs/NEXTCLOUD.md) for the full Nextcloud cloud storage setup
 ## Tdarr Setup
 
 See [TDARR.md](docs/TDARR.md) for the full Tdarr configuration guide (HEVC compression, library setup, transcode flows, Sonarr/Radarr integration).
+
+## RomM Setup
+
+See [`../docs/ROMM.md`](../docs/ROMM.md) for ROM library storage, native authentication, reverse proxy, and Steam Deck setup.
 
 ## Service Catalogue
 

--- a/docker/compose.romm.yml
+++ b/docker/compose.romm.yml
@@ -1,0 +1,71 @@
+# ROM library management
+# romm, romm-db
+
+services:
+  romm:
+    extends:
+      file: compose.common.yml
+      service: common-service
+    image: rommapp/romm:latest
+    container_name: romm
+    environment:
+      DB_HOST: romm-db
+      DB_NAME: romm
+      DB_USER: romm
+      DB_PASSWD: ${ROMM_DB_PASSWORD:?Set ROMM_DB_PASSWORD in .env (openssl rand -hex 32)}
+      ROMM_AUTH_SECRET_KEY: ${ROMM_AUTH_SECRET_KEY:?Set ROMM_AUTH_SECRET_KEY in .env (openssl rand -hex 32)}
+      ROMM_BASE_URL: https://romm.danteb.com
+      HASHEOUS_API_ENABLED: true
+      SCREENSCRAPER_USER: ${ROMM_SCREENSCRAPER_USER}
+      SCREENSCRAPER_PASSWORD: ${ROMM_SCREENSCRAPER_PASSWORD}
+      STEAMGRIDDB_API_KEY: ${ROMM_STEAMGRIDDB_API_KEY}
+      RETROACHIEVEMENTS_API_KEY: ${ROMM_RETROACHIEVEMENTS_API_KEY}
+      ENABLE_RESCAN_ON_FILESYSTEM_CHANGE: true
+      KIOSK_MODE: false
+      DISABLE_DOWNLOAD_ENDPOINT_AUTH: false
+      DISABLE_CSRF_PROTECTION: false
+      TZ: ${TZ}
+    depends_on:
+      romm-db:
+        condition: service_healthy
+        restart: true
+    networks:
+      - proxy
+      - romm
+    volumes:
+      - ${RAID}/shared/games/romm/library:/romm/library
+      - ${DATA}/romm/resources:/romm/resources
+      - ${DATA}/romm/redis-data:/redis-data
+      - ${DATA}/romm/assets:/romm/assets
+      - ${DATA}/romm/config:/romm/config
+
+  romm-db:
+    extends:
+      file: compose.common.yml
+      service: common-service
+    image: mariadb:latest
+    container_name: romm-db
+    environment:
+      MARIADB_ROOT_PASSWORD: ${ROMM_DB_ROOT_PASSWORD:?Set ROMM_DB_ROOT_PASSWORD in .env (openssl rand -hex 32)}
+      MARIADB_DATABASE: romm
+      MARIADB_USER: romm
+      MARIADB_PASSWORD: ${ROMM_DB_PASSWORD:?Set ROMM_DB_PASSWORD in .env (openssl rand -hex 32)}
+      TZ: ${TZ}
+    networks:
+      - romm
+    volumes:
+      - romm-db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 30s
+      start_interval: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  proxy:
+  romm:
+
+volumes:
+  romm-db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,7 @@ include:
   - compose.mcp.yml
   - compose.media.yml
   - compose.nextcloud.yml
+  - compose.romm.yml
   - compose.searxng.yml
   - compose.starr.yml
   - compose.monitoring.yml

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -63,6 +63,19 @@ PLEX_CLAIM=claim-xxxxxx
 ADVERTISE_IP=http://<hostIPAddress>:32400/
 
 # ==============================================================================
+# RomM - ROM library manager
+# ==============================================================================
+# Generate each secret separately with: openssl rand -hex 32
+ROMM_DB_ROOT_PASSWORD=''
+ROMM_DB_PASSWORD=''
+ROMM_AUTH_SECRET_KEY=''
+# Optional metadata providers. Hasheous works without credentials by default.
+ROMM_SCREENSCRAPER_USER=''
+ROMM_SCREENSCRAPER_PASSWORD=''
+ROMM_STEAMGRIDDB_API_KEY=''
+ROMM_RETROACHIEVEMENTS_API_KEY=''
+
+# ==============================================================================
 # Gluetun / qBittorrent (VPN + torrents)
 # ==============================================================================
 WG_PRIVATE_KEY=''

--- a/docs/ROMM.md
+++ b/docs/ROMM.md
@@ -1,0 +1,249 @@
+# RomM
+
+RomM provides the central catalogue and authenticated download service for
+legally owned ROM backups. The server stores the library on the RAID and exposes
+only the RomM web application through Nginx Proxy Manager.
+
+## Storage
+
+RomM uses the recommended top-level `roms/` and `bios/` layout:
+
+```text
+/data/shared/games/romm/library/
+|-- roms/
+|   |-- gba/
+|   |   `-- example.gba
+|   `-- snes/
+|       `-- example.sfc
+`-- bios/
+    |-- gba/
+    `-- ps/
+```
+
+Platform directory names must match a
+[supported RomM platform slug](https://docs.romm.app/latest/platforms/supported-platforms/).
+RomM creates this structure automatically when the first files are uploaded
+through the web UI.
+
+Before starting the stack, create the bind-mount directories with ownership
+matching the default RomM container user:
+
+```bash
+sudo install -d -o 1000 -g 1000 \
+  /data/shared/games/romm/library/{roms,bios} \
+  /srv/docker/data/romm/{resources,redis-data,assets,config}
+```
+
+The MariaDB data is stored in the Docker-managed `romm-db` volume. Uploaded
+saves, save states, screenshots, and other user assets are stored under
+`/srv/docker/data/romm/assets`.
+
+## Import the existing Windows library
+
+The source collection is `D:\iCloudDrive\ROMs`. Its current logical size is
+approximately 58 GiB with more than 15,000 files, but the ROMs are iCloud
+placeholders rather than locally hydrated files. In File Explorer, right-click
+the `ROMs` directory and select **Always keep on this device**, then wait for
+iCloud Drive to finish before staging or transferring anything.
+
+Confirm that no eligible files remain offline:
+
+```powershell
+$files = Get-ChildItem 'D:\iCloudDrive\ROMs' -File -Recurse -Force
+@($files | Where-Object {
+    $_.Attributes -band [System.IO.FileAttributes]::Offline
+}).Count
+```
+
+The result must be `0`. The source directories map to RomM's canonical slugs:
+
+| Source directory | RomM directory |
+|---|---|
+| `Arcade` | `arcade` |
+| `GameBoy` | `gb` |
+| `GameBoy Advance` | `gba` |
+| `GameBoy Color` | `gbc` |
+| `N64` | `n64` |
+| `NDS` | `nds` |
+| `NES` | `nes` |
+| `SNES` | `snes` |
+
+`GameBoy`, `GameBoy Color`, and `NES` currently use region and category
+subdirectories. RomM does not yet support arbitrary platform-level subfolders
+([upstream issue](https://github.com/rommapp/romm/issues/2050)), so the migration
+must flatten those files into the corresponding platform directory. The staging
+script performs that normalization, rejects filename collisions, and excludes
+the old PNG, JPEG, MP4, XML, DAT, SQLite, and text metadata caches. RomM will
+fetch fresh metadata and artwork.
+
+From the repository root on Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\stage-romm-library.ps1
+```
+
+The normalized collection is written to `D:\RomM-Staging\roms`. Existing staged
+files with the expected size are skipped, so the command is safe to rerun.
+
+Use rclone over SFTP for a resumable transfer instead of `scp`:
+
+```powershell
+winget install --id Rclone.Rclone --exact
+rclone config
+```
+
+Create an SFTP remote named `homeserver` with host `192.168.50.100`, user
+`danteb`, port `28`, key file
+`C:\Users\Dante\.ssh\id_ed25519_homeserver`, and
+`C:\Users\Dante\.ssh\known_hosts` as the known-hosts file. This unencrypted key
+has already been verified against the server and is compatible with rclone's
+native SFTP backend. After the RomM directories exist on the server:
+
+```powershell
+rclone copy 'D:\RomM-Staging\roms' `
+  'homeserver:/data/shared/games/romm/library/roms' `
+  --progress --transfers 4 --checkers 8
+
+rclone check 'D:\RomM-Staging\roms' `
+  'homeserver:/data/shared/games/romm/library/roms' `
+  --one-way
+```
+
+Remove `D:\RomM-Staging` only after `rclone check` succeeds and RomM completes
+its first scan.
+
+## Environment
+
+Add these values to `/srv/homeserver/docker/.env`. Generate each secret
+separately; do not reuse one value for multiple settings.
+
+```bash
+openssl rand -hex 32 # ROMM_DB_ROOT_PASSWORD
+openssl rand -hex 32 # ROMM_DB_PASSWORD
+openssl rand -hex 32 # ROMM_AUTH_SECRET_KEY
+```
+
+Hasheous metadata matching is enabled without an API key. The optional
+ScreenScraper, SteamGridDB, and RetroAchievements credentials are documented in
+the [RomM metadata provider guide](https://docs.romm.app/latest/getting-started/metadata-providers/).
+
+Keep `ROMM_AUTH_SECRET_KEY` stable. Changing it invalidates active sessions,
+and invite links. Client API tokens are stored independently and must be
+revoked explicitly.
+
+## Start and initialize
+
+Always use the main Compose entry point so RomM joins the same `proxy` network
+as Nginx Proxy Manager:
+
+```bash
+z /srv/homeserver/docker
+docker compose up -d romm
+docker compose logs -f romm romm-db
+```
+
+After the proxy host is configured, open `https://romm.danteb.com`, complete the
+setup wizard, and create the native administrator account. Use a strong, unique
+password. Create separate accounts for other users so saves and client tokens
+remain isolated.
+
+Upload files through the web interface or place them in the RAID library, then
+start a library scan in RomM. Files copied directly into the library trigger a
+rescan because filesystem-change rescanning is enabled.
+
+Native authentication is the only authentication layer for this deployment.
+Do not enable kiosk mode or unauthenticated download endpoints. RomM stores
+passwords with bcrypt, protects browser requests with CSRF middleware, and
+issues scoped, revocable API tokens to clients.
+
+## Nginx Proxy Manager
+
+Create a proxy host with these settings:
+
+| Setting | Value |
+|---|---|
+| Domain | `romm.danteb.com` |
+| Scheme | `http` |
+| Forward hostname | `romm` |
+| Forward port | `8080` |
+| Cache assets | Off |
+| Block common exploits | On |
+| WebSockets support | On |
+| SSL | Let's Encrypt, Force SSL, HTTP/2 |
+| HSTS | Enable after confirming TLS works |
+
+Add this to the proxy host's **Advanced** configuration:
+
+```nginx
+proxy_max_temp_file_size 0;
+```
+
+This prevents Nginx Proxy Manager from buffering bulk and multi-disc downloads
+to a temporary file. No router port, NixOS firewall rule, or Cloudflare record
+is required; the existing HTTPS proxy and wildcard DNS cover the service.
+
+## Browser downloads
+
+Sign in at `https://romm.danteb.com`, browse or search the library, and download
+only the selected game. RomM also supports browser play through EmulatorJS, but
+browser play is optional and is not required for the download workflow.
+
+For scripts and compatible clients, create a scoped Client API Token in the
+user account instead of storing the account password. Revoke a token when a
+device is retired or lost.
+
+## Steam Deck
+
+[decky-romm-sync](https://github.com/danielcopper/decky-romm-sync) is a
+community-maintained Decky Loader plugin for RomM 4.9.0 or newer. It downloads
+games on demand, adds them to Steam as non-Steam shortcuts, launches them
+through RetroDECK, and can synchronize saves through each user's RomM account.
+It is not maintained by the RomM project, so review its releases before
+upgrading either component.
+
+Prerequisites:
+
+1. Install [RetroDECK](https://retrodeck.net/).
+2. Install [Decky Loader](https://decky.xyz/).
+3. Download the latest `decky-romm-sync.zip` from the
+   [plugin releases](https://github.com/danielcopper/decky-romm-sync/releases).
+4. Follow the plugin's
+   [current installation guide](https://danielcopper.github.io/decky-romm-sync/user-guide/getting-started/).
+5. Connect to `https://romm.danteb.com` using the device-pairing flow or a
+   dedicated scoped client token.
+
+The plugin is pre-1.0 and is not yet in the Decky Store. Its documented manual
+installation currently requires Decky Developer Mode.
+
+## Updates and recovery
+
+RomM tracks the `latest` stable image and is updated by the normal homeserver
+update workflow. Before a major RomM upgrade, review its release notes.
+
+The NixOS daily database backup writes a consistent MariaDB dump to
+`/data/automated-backups/mariadb/daily/`, rotates Sunday copies into `weekly/`,
+and includes both directories in the normal encrypted offsite sync.
+
+To restore a dump into an empty `romm` database:
+
+```bash
+z /srv/homeserver/docker
+gunzip -c /data/automated-backups/mariadb/daily/romm-db-YYYY-MM-DD.sql.gz \
+  | docker exec -i romm-db sh -c \
+      'MYSQL_PWD="$MARIADB_ROOT_PASSWORD" exec mariadb -u root "$MARIADB_DATABASE"'
+```
+
+Stop `romm` while restoring so it cannot write concurrently.
+`/srv/docker/data/romm` is included in the existing daily offsite sync. The ROM
+library under `/data/shared/games/romm/library` is not currently copied offsite;
+protect it separately if the original backups cannot be recreated.
+
+To inspect startup, scan, or authentication failures:
+
+```bash
+z /srv/homeserver/docker
+docker compose logs --tail=200 romm romm-db
+```
+
+RomM does not acquire games. Supply only ROMs and firmware that you are legally
+entitled to store and use.

--- a/homepage/services.yaml
+++ b/homepage/services.yaml
@@ -81,6 +81,17 @@
             url: http://calibre-web:8083
             username: "{{HOMEPAGE_VAR_CALIBRE_USER}}"
             password: "{{HOMEPAGE_VAR_CALIBRE_PASS}}"
+    - RomM:
+        icon: romm.svg
+        href: https://romm.danteb.com
+        description: ROM Library
+        siteMonitor: https://romm.danteb.com
+        server: my-docker
+        container: romm
+        widget:
+          type: romm
+          url: http://romm:8080
+          fields: ["platforms", "totalRoms", "saves", "states"]
 
 - Media Management:
     - Radarr:

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -791,10 +791,10 @@ in
     '';
   };
 
-  # ── Backup automation (Postgres dumps + Vaultwarden + rclone offsite) ─────
+  # ── Backup automation (database dumps + Vaultwarden + rclone offsite) ─────
 
   systemd.services.postgres-backup = {
-    description = "Dump all Postgres databases and copy Vaultwarden data";
+    description = "Dump databases and copy Vaultwarden data";
     after = [ "docker.service" "network-online.target" ];
     requires = [ "docker.service" ];
     wants = [ "network-online.target" ];
@@ -810,11 +810,15 @@ in
 
       BACKUP_ROOT="/data/automated-backups"
       PG_DIR="$BACKUP_ROOT/postgres"
+      MYSQL_DIR="$BACKUP_ROOT/mariadb"
       VW_DIR="$BACKUP_ROOT/vaultwarden"
       DATE=$(date +%Y-%m-%d)
       DOW=$(date +%u)  # 1=Monday, 7=Sunday
 
-      mkdir -p "$PG_DIR/daily" "$PG_DIR/weekly" "$VW_DIR"
+      mkdir -p \
+        "$PG_DIR/daily" "$PG_DIR/weekly" \
+        "$MYSQL_DIR/daily" "$MYSQL_DIR/weekly" \
+        "$VW_DIR"
 
       FAILED=""
       SUCCEEDED=""
@@ -849,16 +853,37 @@ in
         fi
       done
 
+      # RomM MariaDB dump. Read credentials from the container environment so
+      # they never need to be duplicated in the NixOS configuration.
+      MYSQL_DUMP="$MYSQL_DIR/daily/romm-db-''${DATE}.sql.gz"
+      if docker exec romm-db sh -c \
+          'MYSQL_PWD="$MARIADB_ROOT_PASSWORD" exec mariadb-dump --single-transaction --quick --lock-tables=false -u root "$MARIADB_DATABASE"' \
+          2>/dev/null | gzip > "$MYSQL_DUMP"; then
+        if [ "$(stat -c%s "$MYSQL_DUMP" 2>/dev/null || echo 0)" -gt 100 ]; then
+          SUCCEEDED="$SUCCEEDED romm-db"
+        else
+          FAILED="$FAILED romm-db(empty)"
+          rm -f "$MYSQL_DUMP"
+        fi
+      else
+        FAILED="$FAILED romm-db"
+        rm -f "$MYSQL_DUMP"
+      fi
+
       # Weekly rotation: copy Sunday's dumps
       if [ "$DOW" = "7" ]; then
-        for f in "$PG_DIR/daily/"*-"$DATE".sql.gz; do
-          [ -f "$f" ] && cp "$f" "$PG_DIR/weekly/"
+        for dir in "$PG_DIR" "$MYSQL_DIR"; do
+          for f in "$dir/daily/"*-"$DATE".sql.gz; do
+            [ -f "$f" ] && cp "$f" "$dir/weekly/"
+          done
         done
       fi
 
       # Retention: 7 daily, 4 weekly
-      find "$PG_DIR/daily" -name "*.sql.gz" -mtime +7 -delete
-      find "$PG_DIR/weekly" -name "*.sql.gz" -mtime +28 -delete
+      for dir in "$PG_DIR" "$MYSQL_DIR"; do
+        find "$dir/daily" -name "*.sql.gz" -mtime +7 -delete
+        find "$dir/weekly" -name "*.sql.gz" -mtime +28 -delete
+      done
 
       # Vaultwarden backup (SQLite WAL-mode safe for file copy)
       VW_FAILED=""
@@ -1103,4 +1128,3 @@ in
   system.stateVersion = "25.11"; # Did you read the comment?
 
 }
-

--- a/scripts/stage-romm-library.ps1
+++ b/scripts/stage-romm-library.ps1
@@ -1,0 +1,99 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$Source = 'D:\iCloudDrive\ROMs',
+    [string]$Destination = 'D:\RomM-Staging\roms'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$platforms = [ordered]@{
+    'Arcade'          = @{ Slug = 'arcade'; Extensions = @('.zip') }
+    'GameBoy'         = @{ Slug = 'gb';     Extensions = @('.zip', '.gb') }
+    'GameBoy Advance' = @{ Slug = 'gba';    Extensions = @('.zip', '.gba', '.rar', '.7z') }
+    'GameBoy Color'   = @{ Slug = 'gbc';    Extensions = @('.zip', '.gbc') }
+    'N64'             = @{ Slug = 'n64';    Extensions = @('.zip', '.z64', '.n64', '.v64', '.7z') }
+    'NDS'             = @{ Slug = 'nds';    Extensions = @('.zip', '.nds', '.7z') }
+    'NES'             = @{ Slug = 'nes';    Extensions = @('.zip', '.nes', '.7z') }
+    'SNES'            = @{ Slug = 'snes';   Extensions = @('.zip', '.sfc', '.smc', '.7z') }
+}
+
+if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+    throw "ROM library not found: $Source"
+}
+
+$planned = @()
+$targets = @{}
+
+foreach ($entry in $platforms.GetEnumerator()) {
+    $sourceDirectory = Join-Path $Source $entry.Key
+    if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
+        throw "Expected platform directory not found: $sourceDirectory"
+    }
+
+    $files = Get-ChildItem -LiteralPath $sourceDirectory -File -Recurse -Force |
+        Where-Object { $entry.Value.Extensions -contains $_.Extension.ToLowerInvariant() }
+
+    foreach ($file in $files) {
+        $targetDirectory = Join-Path $Destination $entry.Value.Slug
+        $targetPath = Join-Path $targetDirectory $file.Name
+
+        if ($targets.ContainsKey($targetPath)) {
+            throw "Flattening collision: '$($file.FullName)' and '$($targets[$targetPath])' both map to '$targetPath'"
+        }
+
+        $targets[$targetPath] = $file.FullName
+        $planned += [pscustomobject]@{
+            Source = $file
+            TargetDirectory = $targetDirectory
+            TargetPath = $targetPath
+        }
+    }
+}
+
+$offline = @(
+    $planned | Where-Object {
+        $_.Source.Attributes -band [System.IO.FileAttributes]::Offline
+    }
+)
+
+if ($offline.Count -gt 0) {
+    throw "$($offline.Count) ROM files are still cloud-only. In File Explorer, mark '$Source' as 'Always keep on this device', wait for iCloud to finish, and rerun."
+}
+
+$copied = 0
+$skipped = 0
+$written = 0
+$total = $planned.Count
+
+foreach ($item in $planned) {
+    $copied++
+    Write-Progress -Activity 'Staging RomM library' -Status "$copied of $total" -PercentComplete (($copied / $total) * 100)
+
+    if (Test-Path -LiteralPath $item.TargetPath -PathType Leaf) {
+        $existing = Get-Item -LiteralPath $item.TargetPath
+        if ($existing.Length -ne $item.Source.Length) {
+            throw "Existing staged file has a different size: $($item.TargetPath)"
+        }
+
+        $skipped++
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($item.Source.FullName, "Copy to $($item.TargetPath)")) {
+        New-Item -ItemType Directory -Force -Path $item.TargetDirectory | Out-Null
+        Copy-Item -LiteralPath $item.Source.FullName -Destination $item.TargetPath
+        $written++
+    }
+}
+
+Write-Progress -Activity 'Staging RomM library' -Completed
+
+$bytes = ($planned | ForEach-Object { $_.Source.Length } | Measure-Object -Sum).Sum
+if ($WhatIfPreference) {
+    Write-Output "Would stage $total ROM files ($([math]::Round($bytes / 1GB, 2)) GiB) under '$Destination'."
+} else {
+    Write-Output "Staged $written ROM files under '$Destination'."
+}
+if ($skipped -gt 0) {
+    Write-Output "Skipped $skipped files that were already staged with the expected size."
+}


### PR DESCRIPTION
## Summary
- add RomM and MariaDB as an isolated Docker Compose stack
- expose RomM through the shared proxy network with native authentication
- add Homepage monitoring and daily MariaDB backups
- document production setup, NPM configuration, recovery, and Steam Deck usage
- add a Windows staging script for normalizing the existing ROM collection

## Migration status
- copied 11,577 ROMs (54.53 GiB) to `/data/shared/games/romm/library/roms`
- verified all files with rclone checksums; zero differences

## Validation
- rendered the merged Docker Compose configuration
- validated Homepage YAML and NixOS syntax
- checked MariaDB backup utilities and secret handling