### PR TITLE
Exclude generated RomM resources from offsite backup

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -950,10 +950,11 @@ in
         FAILED="$FAILED nextcloud"
       fi
 
-      # Selective /srv/docker/data (service configs, ~4.5 GB)
+      # Selective /srv/docker/data (service configs and non-regenerable app data)
       if ! rclone sync /srv/docker/data/ "$REMOTE/docker-data/" \
           --exclude "plex/**" \
           --exclude "jellyfin/**" \
+          --exclude "romm/resources/**" \
           --exclude "satisfactory-server/**" \
           --exclude "syncthing/**" \
           --exclude "tdarr/logs/**" \


### PR DESCRIPTION
## Summary
- exclude RomM's regenerable `resources` tree from the daily Google Drive sync
- continue backing up RomM configuration, assets/saves, and Redis state
- prevent the 391,000-file metadata tree from repeatedly exhausting the 8-hour service timeout

## Validation
- parsed the updated NixOS configuration with `nix-instantiate --parse`
- checked the diff with `git diff --check`